### PR TITLE
Fix: Update default compileSdkVersion from 31 to 34 for Android API 3…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ android {
     if (project.android.hasProperty("namespace")) {
         namespace 'io.agora.agora_rtc_ng'
     }
-    compileSdkVersion safeExtGet('compileSdkVersion', 31)
+    compileSdkVersion safeExtGet('compileSdkVersion', 34)
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)


### PR DESCRIPTION
…4 compatibility

- Resolves build failures with Android API 34 dependencies
- Fixes checkReleaseAarMetadata task failures for iris_method_channel
- Ensures compatibility with androidx dependencies requiring API 34+
- Addresses issues with androidx.fragment, androidx.window, and other dependencies
- Maintains backward compatibility through safeExtGet fallback mechanism

Fixes: Build failures when using Agora Flutter SDK with Android API 34